### PR TITLE
Added transparent support for a list of paths as source

### DIFF
--- a/zipstream.py
+++ b/zipstream.py
@@ -196,8 +196,8 @@ class ZipStream:
 
     def __iter__(self):
 	for p in self.path:
-		for data in self.zip_path(p, self.arc_path):
-	    	yield data
+            for data in self.zip_path(p, self.arc_path):
+	        yield data
 
         yield self.archive_footer()
 


### PR DESCRIPTION
Hello, 
I needed to send ZipStream a list of path from which to build the zip, I've edited the code to transparently support this feature (very simple).

Bye,
Gianluca
